### PR TITLE
Add support for backup codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@
 * Support for 2 types of OTP codes
  1. Codes delivered directly to the user
  2. TOTP (Google Authenticator) codes based on a shared secret (HMAC)
+ 3. A set of pre-shared backup codes
 * Configurable OTP code digit length
 * Configurable max login attempts
 * Customizable logic to determine if a user needs two factor authentication
 * Configurable period where users won't be asked for 2FA again
+* Backup codes hashed when stored in the database
 * Option to encrypt the TOTP secret in the database, with iv and salt
 
 ## Configuration
@@ -107,7 +109,7 @@ below):
 
 ```ruby
 def send_two_factor_authentication_code(code)
-  # Send code via SMS, etc.
+  # Send code directly to user via SMS, etc.
 end
 ```
 

--- a/app/views/devise/two_factor_authentication/show.html.erb
+++ b/app/views/devise/two_factor_authentication/show.html.erb
@@ -13,7 +13,9 @@
 
 <% if current_user.direct_otp %>
 <%= link_to "Resend Code", resend_code_user_two_factor_authentication_path, action: :get %>
+<%= link_to "Use App", use_totp_code_user_two_factor_authentication_path, action: :get %>
 <% else %>
 <%= link_to "Send me a code instead", resend_code_user_two_factor_authentication_path, action: :get %>
 <% end %>
+<%= link_to "Use Backup Code", use_backup_code_user_two_factor_authentication_path, action: :get %>
 <%= link_to "Sign out", destroy_user_session_path, :method => :delete %>

--- a/app/views/devise/two_factor_authentication/show_backup.html.erb
+++ b/app/views/devise/two_factor_authentication/show_backup.html.erb
@@ -1,0 +1,12 @@
+<h2>Enter one of your backup codes</h2>
+
+<p><%= flash[:notice] %></p>
+
+<%= form_tag([resource_name, :two_factor_authentication], :method => :put) do %>
+  <%= text_field_tag :backup_code %>
+  <%= submit_tag "Submit" %>
+<% end %>
+
+<%= link_to "Use Direct Code Delivery", user_two_factor_authentication_path, action: :get %>
+<%= link_to "Use App", use_totp_code_user_two_factor_authentication_path, action: :get %>
+<%= link_to "Sign out", destroy_user_session_path, :method => :delete %>

--- a/app/views/devise/two_factor_authentication/show_totp.html.erb
+++ b/app/views/devise/two_factor_authentication/show_totp.html.erb
@@ -1,0 +1,12 @@
+<h2>Enter the authentication code from your app</h2>
+
+<p><%= flash[:notice] %></p>
+
+<%= form_tag([resource_name, :two_factor_authentication], :method => :put) do %>
+  <%= text_field_tag :totp_code %>
+  <%= submit_tag "Submit" %>
+<% end %>
+
+<%= link_to "Use Direct Code Delivery", user_two_factor_authentication_path, action: :get %>
+<%= link_to "Use Backup Code", use_backup_code_user_two_factor_authentication_path, action: :get %>
+<%= link_to "Sign out", destroy_user_session_path, :method => :delete %>

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -7,6 +7,7 @@ class TwoFactorAuthenticationAddTo<%= table_name.camelize %> < ActiveRecord::Mig
     add_column :<%= table_name %>, :direct_otp, :string
     add_column :<%= table_name %>, :direct_otp_sent_at, :datetime
     add_column :<%= table_name %>, :totp_timestamp, :timestamp
+    add_column :<%= table_name %>, :backup_codes, :string
 
     add_index :<%= table_name %>, :encrypted_otp_secret_key, unique: true
   end

--- a/lib/two_factor_authentication.rb
+++ b/lib/two_factor_authentication.rb
@@ -27,6 +27,12 @@ module Devise
 
   mattr_accessor :otp_secret_encryption_key
   @@otp_secret_encryption_key = ''
+
+  mattr_accessor :backup_code_length
+  @@backup_code_length = 8
+
+  mattr_accessor :backup_code_count
+  @@backup_code_count = 10
 end
 
 module TwoFactorAuthentication

--- a/lib/two_factor_authentication/routes.rb
+++ b/lib/two_factor_authentication/routes.rb
@@ -4,7 +4,11 @@ module ActionDispatch::Routing
 
       def devise_two_factor_authentication(mapping, controllers)
         resource :two_factor_authentication, :only => [:show, :update, :resend_code], :path => mapping.path_names[:two_factor_authentication], :controller => controllers[:two_factor_authentication] do
-          collection { get "resend_code" }
+          collection do
+            get "use_totp_code"
+            get "use_backup_code"
+            get "resend_code"
+          end
         end
       end
   end

--- a/lib/two_factor_authentication/schema.rb
+++ b/lib/two_factor_authentication/schema.rb
@@ -27,5 +27,9 @@ module TwoFactorAuthentication
     def totp_timestamp
       apply_devise_schema :totp_timestamp, Timestamp
     end
+
+    def backup_codes
+      apply_devise_schema :backup_codes, String
+    end
   end
 end

--- a/spec/rails_app/app/models/guest_user.rb
+++ b/spec/rails_app/app/models/guest_user.rb
@@ -5,7 +5,13 @@ class GuestUser
 
   define_model_callbacks :create
   attr_accessor :direct_otp, :direct_otp_sent_at, :otp_secret_key, :email,
-    :second_factor_attempts_count, :totp_timestamp
+    :second_factor_attempts_count, :totp_timestamp, :backup_codes
+
+  mattr_accessor :pepper
+  @@pepper = nil
+
+  mattr_accessor :stretches
+  @@stretches = 2
 
   def update_attributes(attrs)
     attrs.each do |key, value|

--- a/spec/support/authenticated_model_helper.rb
+++ b/spec/support/authenticated_model_helper.rb
@@ -50,6 +50,7 @@ module AuthenticatedModelHelper
           t.string    'direct_otp'
           t.datetime  'direct_otp_sent_at'
           t.timestamp 'totp_timestamp'
+          t.string    'backup_codes'
         end
       end
     end


### PR DESCRIPTION
Backup codes also generated randomly and stored one-way-hashed
in the database using Devise::Encryptor.  They default to 8
decimal digits rather than 6 since they are longer lived than
direct OTP codes.
